### PR TITLE
Hooks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,8 @@ gem 'rake'
 gem 'coveralls', require: false
 
 group :test do
-  gem "test"
+  gem "minitest"
+  gem "rack-test"
   gem "mocha"
   gem "grack", :git => 'https://github.com/grackorg/grack'
   gem "simplecov", :require => false

--- a/lib/hooks.rb
+++ b/lib/hooks.rb
@@ -1,0 +1,44 @@
+module Grack 
+  module Hooks
+
+    class Hook
+      def initialize(hook)
+        @hook = hook
+      end
+    end
+
+    class PreReceiveHook < Hook
+      include org.eclipse.jgit.transport.PreReceiveHook
+      def onPreReceive(pack, commands)
+        @hook.call(pack, commands.to_a)
+      end
+    end
+
+    class PostReceiveHook < Hook
+      include org.eclipse.jgit.transport.PostReceiveHook
+      def onPostReceive(pack, commands)
+        @hook.call(pack, commands.to_a)
+      end
+    end
+
+    class PostUploadHook < Hook
+      include org.eclipse.jgit.transport.PostUploadHook
+      def onPostUpload(stats)
+        @hook.call(stats)
+      end
+    end
+
+    class PreUploadHook < Hook
+      include org.eclipse.jgit.transport.PreUploadHook
+
+      def onSendPack(pack, wants, haves)
+        @hook.call(pack, wants.to_a, haves.to_a)
+      end
+
+      def onBeginNegotiateRound(pack, wants, cnt_offered); end
+      def onEndNegotiateRound(pack, wants, cnt_common, cnt_not_found, ready ); end
+
+    end
+
+  end
+end

--- a/lib/hooks.rb
+++ b/lib/hooks.rb
@@ -10,14 +10,29 @@ module Grack
     class PreReceiveHook < Hook
       include org.eclipse.jgit.transport.PreReceiveHook
       def onPreReceive(pack, commands)
-        @hook.call(pack, commands.to_a)
+        @hook.call(commands.to_a.map {|cmd|
+          {
+            :ref_name => cmd.getRefName,
+            :old_id => cmd.getOldId.getName,
+            :new_id => cmd.getNewId.getName,
+            :type => cmd.getType.toString,
+          }
+        })
       end
     end
 
     class PostReceiveHook < Hook
       include org.eclipse.jgit.transport.PostReceiveHook
       def onPostReceive(pack, commands)
-        @hook.call(pack, commands.to_a)
+        @hook.call(commands.to_a.map {|cmd|
+          {
+            :ref_name => cmd.getRefName,
+            :old_id => cmd.getOldId.getName,
+            :new_id => cmd.getNewId.getName,
+            :type => cmd.getType.toString,
+            :result => cmd.getResult.toString
+          }
+        })
       end
     end
 
@@ -32,7 +47,7 @@ module Grack
       include org.eclipse.jgit.transport.PreUploadHook
 
       def onSendPack(pack, wants, haves)
-        @hook.call(pack, wants.to_a, haves.to_a)
+        @hook.call(wants.to_a.map {|obj| obj.getName}, haves.to_a.map {|obj| obj.getName})
       end
 
       def onBeginNegotiateRound(pack, wants, cnt_offered); end

--- a/tests/rjgitadapter_test.rb
+++ b/tests/rjgitadapter_test.rb
@@ -1,24 +1,130 @@
 require 'rubygems'
-require 'test/unit'
+require 'minitest/autorun'
+require 'minitest/unit'
+require 'rack/test'
 require 'mocha/setup'
-require 'grack/git_adapter'
 require 'stringio'
+require 'grack/app'
 
 require './lib/rjgit_grack'
 
-
-class RJGitAdapterTest < Test::Unit::TestCase
+class RJGitAdapterTest < Minitest::Test
   include Grack
   
   def example
     File.expand_path(File.join(File.dirname(__FILE__),'example'))
   end
   
-  def test_repo
+  def stock_repo
     File.join(example, 'test_repo')
   end
 
+  def test_repo
+    @test_repo
+  end
+
   def setup
+    init_example_repository
+  end
+
+  def teardown
+    remove_example_repository
+  end
+
+  def init_example_repository
+    @repositories_root = Pathname.new(Dir.mktmpdir('grack-testing'))
+    @test_repo = @repositories_root + 'example_repo.git'
+
+    FileUtils.cp_r(stock_repo, @test_repo)
+  end
+
+  def remove_example_repository
+    FileUtils.remove_entry_secure(@repositories_root)
+  end
+end
+
+
+class HookTest < RJGitAdapterTest
+  include Rack::Test::Methods
+
+  def hooks
+    {
+      :postUpload => Proc.new do |pack, wants, haves|
+        @postupload = true
+      end,
+      :preUpload => Proc.new do |pack, wants, haves|
+        @preupload = true
+      end,
+      :preReceive => Proc.new do |pack, commands|
+        @prereceive = true
+      end,
+      :postReceive => Proc.new do |pack, commands|
+        @postreceive = true
+      end
+    }
+  end
+
+  def app
+    Grack::App.new(app_config)
+  end
+
+  def app_config
+    {
+      :root => @repositories_root,
+      :allow_pull => true,
+      :allow_push => true,
+      :git_adapter_factory => ->{ RJGitAdapter.new(hooks) }
+    }
+  end
+
+  def example_repo_urn
+    '/example_repo.git'
+  end
+
+  def setup
+    super
+    @prereceive = false
+    @postreceive = false
+    @preupload = false
+    @postupload = false
+  end
+
+  def test_receive_hook
+    assert_equal false, @prereceive
+    assert_equal false, @postreceive
+
+    data = "00a5cb067e06bdf6e34d4abebf6cf2de85d65a52c65e 9a95842eb477aec2ee7938e354a254c35857e94e refs/heads/master\x00 report-status side-band-64k agent=git/1.9.5.(Apple.Git-50.3)0000PACK\x00\x00\x00\x02\x00\x00\x00\x03\x91\x0Ex\x9C\x9D\xCBA\n\xC3 \x10@\xD1\xBD\xA7p_\b:\xEA\x98B\t]t\xDFM/0\xEAH\x02I\f\xE9\x84^\xBF\xA1G\xE8\xF2\xC1\xFF\xB23k\xA0DW \xAA\xC0\x06k\x8E\xD6x\x9F\xAC\xA5\xC0\xBDs\xD9E\x88\x19-\x93U\e\xED\xBC\x8A\xCE\xC9`<\xD3T*\xB2\xF3\xC5S\xE2T1W(\xDC\x87\x82\x81\x02d\f\xAC\xE8\x90\xB1\xED\xFAA\x1F\xD2\xCF\x85E\x9A\xBE\x95\x13]\xFB\xE1\xBE\x8D\xD3\xDC\x1DG\xB7\xCE\x83\xB6>\x18\xF4\x0E<\xEA\x8B\xB1\xC6\xA8\xDC\x96e\x12\xE1\x7F\x7F\xF5\xE2\xB7\xA8/\x8CJD\xB1\xA0\x02x\x9C340031Q(I-.a\xD8\xB4\xF3\xCC\xF4\xDD\xFC.\xA2\xE7\xF2O\x8B]_\xC2s6\xE1\xB7\x97\x03\x00\xC0\x92\rX;x\x9C\xCBH\xCD\xC9\xC9\xE7*I-.\xE1\x02\x00\x19\t\x03\xE9\x91&)\xD1#\xD6\xB0\x81,\x152\xA4\xFA\xF2p\xF3\xC6\xA5\x9CT"
+    post(
+      "#{example_repo_urn}/git-receive-pack",
+      data,
+      {'CONTENT_TYPE' => 'application/x-git-receive-pack-request'}
+    )
+
+    assert_equal true, @prereceive
+    assert_equal true, @postreceive
+  end
+
+  def test_upload_hook
+    assert_equal false, @preupload
+    assert_equal false, @postupload
+    data = "0090want cb067e06bdf6e34d4abebf6cf2de85d65a52c65e multi_ack_detailed no-done side-band-64k thin-pack ofs-delta agent=git/1.9.5.(Apple.Git-50.3)\n0032want cb067e06bdf6e34d4abebf6cf2de85d65a52c65e\n00000009done\n"
+
+    post(
+      "#{example_repo_urn}/git-upload-pack",
+      data,
+      {'CONTENT_TYPE' => 'application/x-git-upload-pack-request'}
+    )
+
+    assert_equal true, @preupload
+    assert_equal true, @postupload
+  end
+
+end
+
+class RJGitAdapterAPITest < RJGitAdapterTest
+
+  def setup
+    super
     @test_git = RJGitAdapter.new
     @test_git.repository_path = test_repo
   end


### PR DESCRIPTION
This implements support for JGit hooks. There are four types of hooks:
- PreReceive
- PostReceive
- PreUpload
- PostUpload

The user can set these hooks by passing an (optional) hash to the RJGitAdapter's initializer:

``` ruby
adapter = RJGitAdapter.new({
  :preReceive => Proc.new do
    puts "This code is executed in the hook!"
  end
})
```

JGit blocks the receive or upload action from completing until the hook is completed, so the user should only run quick code in the hooks (presumably launching new threads/workers to do the more complicated tasks).

JGit allows users to set hooks for three different stages of the `preUpload` phase, (`onBeginNegotiate`, `onEndNegotiate`, `onSendPack`). In this implementation, only the `onSendPack` hook is supported (which is called immediately before a pack is uploaded).

At the moment, the hooks pass on the objects that JGit provides to the `onPostReceive` and similiar methods. So for example, if a user defines a block to be called on post receive, that block will receive a jgit pack object and an array of jgit command objects with result codes when it is called.

It doesn't seem very user friendly to expose JGit core objects to the end user, so I think an API will have to be defined and the jgit objects will have to be wrapped to ruby hashes or structs. However, I'm not sure what information it would make sense to wrap and expose to the end user for each hook. Definitely the object-id's of any refs that were transfered, but what else? @javanthropus, do you know if there are any standards concerning the information that hook authors should have available?

I've thought about how we could implement hooks using the standard grit adapter, but I think it's not possible to do that. It would require analysing the traffic to and from the client, which would be non-trivial and quite performance heavy.

/cc @bartkamphorst
